### PR TITLE
fix atomic typedef to compile with C++14

### DIFF
--- a/SeRoNetSDK/SeRoNet/OPCUA/Client/AsyncSubscription.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Client/AsyncSubscription.hpp
@@ -15,7 +15,7 @@ template<typename T_DATATYPE>
 ///TODO Add invalid flag
 class AsyncSubscription {
  public:
-  typedef std::atomic_int64_t atomic_counter_t;
+  typedef std::atomic<std::int64_t> atomic_counter_t;
   typedef std::int64_t counter_t;
 
   virtual ~AsyncSubscription() = 0;


### PR DESCRIPTION
I have fixed a typedef in AsycSubscriber that before prevented from compiling with C++14. I think this is an uncritical fix so please check and accept it.