### PR TITLE
fix namespace compiler errors and fix CMake for usnig the SmartSoft API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cmake-build*
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(ENABLE_CODECOVERAGE OFF CACHE BOOL "Enables the codecoverage")
 
 find_package(open62541 REQUIRED)
 find_package(Open62541Cpp REQUIRED)
-find_package(SmartSoft_CD_API REQUIRED)
+find_package(SmartSoft_CD_API PATHS $ENV{SMART_ROOT_ACE}/modules REQUIRED)
 
 if ( ENABLE_CODECOVERAGE )
 

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterRequestDescription.cpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterRequestDescription.cpp
@@ -5,14 +5,18 @@
 #include "ParameterRequestDescription.hpp"
 #include "ParameterRequestIdlDescription.hpp"
 
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
+
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription<
+IDescription::shp_t SelfDescription<
     SeRoNet::DefaultCommObjects::CommParameterRequest>(
     SeRoNet::DefaultCommObjects::CommParameterRequest *obj,
     std::string name) {
 
-  SeRoNet::CommunicationObjects::Description::ComplexType::shp_t ret(
-      new SeRoNet::CommunicationObjects::Description::ComplexType(name)
+  ComplexType::shp_t ret(
+      new ComplexType(name)
   );
 
   // Add Member
@@ -22,4 +26,8 @@ SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::Communi
   );
 
   return ret;
+}
+
+}
+}
 }

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterRequestDescription.hpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterRequestDescription.hpp
@@ -8,8 +8,15 @@
 
 #include "../../CommunicationObjects/Description/SelfDescription.hpp"
 
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
 
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription<SeRoNet::DefaultCommObjects::CommParameterRequest>(
+IDescription::shp_t SelfDescription<SeRoNet::DefaultCommObjects::CommParameterRequest>(
     SeRoNet::DefaultCommObjects::CommParameterRequest *obj,
     std::string name);
+
+}
+}
+}

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterRequestIdlDescription.hpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterRequestIdlDescription.hpp
@@ -9,16 +9,23 @@
 #include "../../CommunicationObjects/Description/SelfDescription.hpp"
 #include "../../DefaultCommObjects/ParameterRequest.hpp"
 
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
 
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription
+IDescription::shp_t SelfDescription
 <SeRoNet::DefaultCommObjects::CommParameterIDL::NameValue>
 (
     SeRoNet::DefaultCommObjects::CommParameterIDL::NameValue *obj,
     std::string name);
 
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription<
+IDescription::shp_t SelfDescription<
     SeRoNet::DefaultCommObjects::CommParameterIDL::CommParameterRequest>(
     SeRoNet::DefaultCommObjects::CommParameterIDL::CommParameterRequest *obj,
     std::string name);
+
+}
+}
+}

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterResponseDescription.cpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterResponseDescription.cpp
@@ -5,16 +5,18 @@
 #include "ParameterResponseIdlDescription.hpp"
 #include "../../CommunicationObjects/Description/ComplexType.hpp"
 
-
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
 
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription(
+IDescription::shp_t SelfDescription(
         SeRoNet::DefaultCommObjects::CommParameterResponse *obj,
         std::string name
     ) {
 
-  SeRoNet::CommunicationObjects::Description::ComplexType::shp_t ret(
-      new SeRoNet::CommunicationObjects::Description::ComplexType(name)
+  ComplexType::shp_t ret(
+      new ComplexType(name)
   );
 
 //  Add Members
@@ -25,3 +27,6 @@ SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::Communi
   return ret;
 }
 
+}
+}
+}

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterResponseDescription.hpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterResponseDescription.hpp
@@ -10,8 +10,16 @@
 #include "../../DefaultCommObjects/ParameterResponse.hpp"
 #include "../../CommunicationObjects/Description/SelfDescription.hpp"
 
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
+
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription(
+IDescription::shp_t SelfDescription(
     SeRoNet::DefaultCommObjects::CommParameterResponse *obj,
     std::string name
 );
+
+}
+}
+}

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterResponseIdlDescription.hpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/ParameterResponseIdlDescription.hpp
@@ -8,10 +8,16 @@
 #include "../../CommunicationObjects/Description/SelfDescription.hpp"
 #include "../../DefaultCommObjects/CommParameterIDL/ParameterResponseIdl.hpp"
 
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
 
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription<
+IDescription::shp_t SelfDescription<
     SeRoNet::DefaultCommObjects::CommParameterIDL::CommParameterResponse>(
     SeRoNet::DefaultCommObjects::CommParameterIDL::CommParameterResponse *obj,
     std::string name);
 
+}
+}
+}

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/WiringCommObjectDescription.cpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/WiringCommObjectDescription.cpp
@@ -7,8 +7,12 @@
 #include "../../CommunicationObjects/Description/ComplexType.hpp"
 #include "../../CommunicationObjects/Description/ElementPrimitives.hpp"
 
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
+
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription(
+IDescription::shp_t SelfDescription(
     DefaultCommObjects::WiringCommObject *obj,
 
     std::string name) {
@@ -72,4 +76,8 @@ SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::Communi
   );
 
   return ret;
+}
+
+}
+}
 }

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/WiringCommObjectDescription.hpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/Description/WiringCommObjectDescription.hpp
@@ -8,9 +8,16 @@
 #include "../../DefaultCommObjects/WiringCommObject.hpp"
 #include "../../CommunicationObjects/Description/SelfDescription.hpp"
 
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
 
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription(
+IDescription::shp_t SelfDescription(
     SeRoNet::DefaultCommObjects::WiringCommObject *obj,
     std::string name
 );
+
+}
+}
+}

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/ParameterRequest.hpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/ParameterRequest.hpp
@@ -14,7 +14,7 @@
 
 //SeRoNet class
 #include "../CommunicationObjects/ICommunicationObject.hpp"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartICommunicationObject.h"
+#include "smartICommunicationObject.h"
 
 namespace SeRoNet {
 namespace DefaultCommObjects {

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/ParameterResponse.hpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/ParameterResponse.hpp
@@ -13,7 +13,7 @@
 // include enums
 #include "EnumParamResponseType.hpp"
 #include "../CommunicationObjects/ICommunicationObject.hpp"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartICommunicationObject.h"
+#include "smartICommunicationObject.h"
 
 namespace SeRoNet {
 namespace DefaultCommObjects {

--- a/SeRoNetSDK/SeRoNet/DefaultCommObjects/WiringCommObject.hpp
+++ b/SeRoNetSDK/SeRoNet/DefaultCommObjects/WiringCommObject.hpp
@@ -6,7 +6,7 @@
 #define SERONETSDK_WIRING_HPP
 
 #include <string>
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartStatusCode.h"
+#include "smartStatusCode.h"
 namespace SeRoNet {
 namespace DefaultCommObjects {
 

--- a/SeRoNetSDK/SeRoNet/OPCUA/Client/EventClient.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Client/EventClient.hpp
@@ -4,7 +4,7 @@
 /// \date 06.09.2018
 ///
 
-#include <SmartSoft_CD_API/smartIEventClientPattern_T.h>
+#include <smartIEventClientPattern_T.h>
 #include <chrono>
 #include <memory>
 #include "NamingServiceOpcUa.hpp"

--- a/SeRoNetSDK/SeRoNet/OPCUA/Client/PushClient.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Client/PushClient.hpp
@@ -8,7 +8,7 @@
 
 #include "AsyncSubscriptionOpcUa.hpp"
 #include "AsyncSubscriptionReader.hpp"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIPushClientPattern_T.h"
+#include "smartIPushClientPattern_T.h"
 #include "AsyncSubscriptionWithCommObject.hpp"
 
 #include <open62541.h>

--- a/SeRoNetSDK/SeRoNet/OPCUA/Client/QClientOPCUA.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Client/QClientOPCUA.hpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <chrono>
 
-#include <SmartSoft_CD_API/smartIQueryClientPattern_T.h>
+#include <smartIQueryClientPattern_T.h>
 #include "AsyncAnswer.hpp"
 
 #include "../../Exceptions/BlockingDisabledException.hpp"

--- a/SeRoNetSDK/SeRoNet/OPCUA/Client/SendClient.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Client/SendClient.hpp
@@ -5,7 +5,7 @@
 ///
 #pragma once
 
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartISendClientPattern_T.h"
+#include "smartISendClientPattern_T.h"
 #include "UaClientWithMutex.hpp"
 #include "SeRoNet/OPCUA/Converter/CommObjectToUaVariantArray.hpp"
 #include "../../CommunicationObjects/ICommunicationObject.hpp"

--- a/SeRoNetSDK/SeRoNet/OPCUA/Server/EventServer.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Server/EventServer.hpp
@@ -4,15 +4,15 @@
 
 #pragma once
 
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIEventServerPattern_T.h"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartStatusCode.h"
+#include "smartIEventServerPattern_T.h"
+#include "smartStatusCode.h"
 #include "../../Utils/Component.hpp"
 #include <sstream>
 #include <Open62541Cpp/UA_String.hpp>
 #include <open62541/open62541.h>
 #include "../../CommunicationObjects/Description/SelfDescription.hpp"
 #include "PushServerUpdater.hpp"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIEventClientPattern_T.h"
+#include "smartIEventClientPattern_T.h"
 #include "SeRoNet/OPCUA/Converter/CommObjectToUaArgument.hpp"
 #include "../../Exceptions/NotImplementedException.hpp"
 #include "SeRoNet/OPCUA/Converter/CommObjectToPushModel.hpp"

--- a/SeRoNetSDK/SeRoNet/OPCUA/Server/OpcuaServer.cpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Server/OpcuaServer.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <Open62541Cpp/UA_String.hpp>
 #include "OpcuaServer.hpp"
+
 namespace SeRoNet {
 namespace OPCUA {
 namespace Server {

--- a/SeRoNetSDK/SeRoNet/OPCUA/Server/PushServer.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Server/PushServer.hpp
@@ -10,8 +10,8 @@
 #include <open62541.h>
 #include <Open62541Cpp/UA_ArrayOfVariant.hpp>
 #include "../../Utils/Component.hpp"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartStatusCode.h"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIPushServerPattern_T.h"
+#include "smartStatusCode.h"
+#include "smartIPushServerPattern_T.h"
 #include "SeRoNet/OPCUA/Converter/CommObjectToPushModel.hpp"
 #include "SeRoNet/OPCUA/Converter/CommObjectToUaVariantArray.hpp"
 #include "PushServerUpdater.hpp"

--- a/SeRoNetSDK/SeRoNet/OPCUA/Server/QueryServer.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Server/QueryServer.hpp
@@ -19,10 +19,10 @@
 #include <sstream>
 #include <Open62541Cpp/UA_NodeId.hpp>
 
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIComponent.h"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartStatusCode.h"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartICommunicationObject.h"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIQueryServerPattern_T.h"
+#include "smartIComponent.h"
+#include "smartStatusCode.h"
+#include "smartICommunicationObject.h"
+#include "smartIQueryServerPattern_T.h"
 
 #include "../../Utils/Component.hpp"
 #include "../../CommunicationObjects/ICommunicationObject.hpp"

--- a/SeRoNetSDK/SeRoNet/OPCUA/Server/QueryServerHandler.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Server/QueryServerHandler.hpp
@@ -3,8 +3,8 @@
 
 ////#include "SeRoNet/Utils/IObserver.hpp"
 #include "QueryServer.hpp"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIQueryServerPattern_T.h"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartICommunicationObject.h"
+#include "smartIQueryServerPattern_T.h"
+#include "smartICommunicationObject.h"
 
 namespace SeRoNet {
 namespace OPCUA {

--- a/SeRoNetSDK/SeRoNet/OPCUA/Server/SendServer.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Server/SendServer.hpp
@@ -9,7 +9,7 @@
 #include <Open62541Cpp/UA_ArrayOfVariant.hpp>
 #include <thread>
 #include <sstream>
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartISendServerPattern_T.h"
+#include "smartISendServerPattern_T.h"
 #include "../../Utils/Component.hpp"
 #include "SeRoNet/OPCUA/Converter/CommObjectToUaArgument.hpp"
 #include "SeRoNet/OPCUA/Converter/CommObjectToUaVariantArray.hpp"

--- a/SeRoNetSDK/SeRoNet/OPCUA/Server/SendServerHandler.hpp
+++ b/SeRoNetSDK/SeRoNet/OPCUA/Server/SendServerHandler.hpp
@@ -7,9 +7,9 @@
 
 #include "SendServer.hpp"
 
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIInputHandler_T.h"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartISendServerPattern_T.h"
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartICommunicationObject.h"
+#include "smartIInputHandler_T.h"
+#include "smartISendServerPattern_T.h"
+#include "smartICommunicationObject.h"
 
 namespace SeRoNet {
 namespace OPCUA {

--- a/SeRoNetSDK/SeRoNet/State/CommObjs.hpp
+++ b/SeRoNetSDK/SeRoNet/State/CommObjs.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartICommunicationObject.h"
+#include "smartICommunicationObject.h"
 
 namespace SeRoNet {
 

--- a/SeRoNetSDK/SeRoNet/State/StateMaster.hpp
+++ b/SeRoNetSDK/SeRoNet/State/StateMaster.hpp
@@ -8,8 +8,8 @@
 
 #include "CommObjs.hpp"
 #include "../Exceptions/SeRoNetSDKException.hpp"
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartStatusCode.h"
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIComponent.h"
+#include "smartStatusCode.h"
+#include "smartIComponent.h"
 #include "../OPCUA/Client/QueryClient.hpp"
 
 namespace SeRoNet {

--- a/SeRoNetSDK/SeRoNet/State/StateSlave.hpp
+++ b/SeRoNetSDK/SeRoNet/State/StateSlave.hpp
@@ -19,7 +19,7 @@ class StateSlave;
 #include "StateUpdateThread.hpp"
 #include "StateChangeHandler.hpp"
 #include <list>
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIComponent.h"
+#include "smartIComponent.h"
 #include <condition_variable>
 #include "StateSlaveHandler.hpp"
 

--- a/SeRoNetSDK/SeRoNet/State/StateSlaveHandler.hpp
+++ b/SeRoNetSDK/SeRoNet/State/StateSlaveHandler.hpp
@@ -14,7 +14,7 @@ class StateSlaveHandler;
 
 #include "StateSlave.hpp"
 
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartQueryStatus.h"
+#include "smartQueryStatus.h"
 #include "../OPCUA/Server/QueryServerHandler.hpp"
 
 namespace SeRoNet {

--- a/SeRoNetSDK/SeRoNet/State/StateUpdateThread.cpp
+++ b/SeRoNetSDK/SeRoNet/State/StateUpdateThread.cpp
@@ -49,7 +49,7 @@ void StateUpdateThread::sleep_for(const std::chrono::steady_clock::duration &rel
 }
 int StateUpdateThread::start() {
   if (!m_thread.joinable()) {
-    m_thread = std::thread(&task_execution, this);
+    m_thread = std::thread(&StateUpdateThread::task_execution, this);
   }
   return 0;
 }

--- a/SeRoNetSDK/SeRoNet/State/StateUpdateThread.hpp
+++ b/SeRoNetSDK/SeRoNet/State/StateUpdateThread.hpp
@@ -8,7 +8,7 @@
 
 #include <thread>
 #include <atomic>
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIManagedTask.h"
+#include "smartIManagedTask.h"
 
 namespace SeRoNet {
 

--- a/SeRoNetSDK/SeRoNet/Utils/ActiveQueueInputHandlerDecorator.hpp
+++ b/SeRoNetSDK/SeRoNet/Utils/ActiveQueueInputHandlerDecorator.hpp
@@ -5,7 +5,7 @@
 #ifndef SERONETSDK_ACTIVEQUEUEINPUTHANDLERDECORATOR_HPP
 #define SERONETSDK_ACTIVEQUEUEINPUTHANDLERDECORATOR_HPP
 
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIActiveQueueInputHandlerDecorator_T.h"
+#include "smartIActiveQueueInputHandlerDecorator_T.h"
 #include "Task.hpp"
 #include "../OPCUA/Server/QueryServerHandler.hpp"
 

--- a/SeRoNetSDK/SeRoNet/Utils/Component.hpp
+++ b/SeRoNetSDK/SeRoNet/Utils/Component.hpp
@@ -6,8 +6,8 @@
 #include <open62541.h>
 #include "../OPCUA/Server/OpcuaServer.hpp"
 
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIComponent.h"
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartStatusCode.h"
+#include "smartIComponent.h"
+#include "smartStatusCode.h"
 
 namespace SeRoNet {
 namespace Utils {

--- a/SeRoNetSDK/SeRoNet/Utils/HsUlm/smartProcessingPattern.hpp
+++ b/SeRoNetSDK/SeRoNet/Utils/HsUlm/smartProcessingPattern.hpp
@@ -34,7 +34,7 @@
 #ifndef _SMARTPROCESSINGPATTERNS_HH
 #define _SMARTPROCESSINGPATTERNS_HH
 
-#include "../../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIActiveQueueInputHandlerDecorator_T.h"
+#include "smartIActiveQueueInputHandlerDecorator_T.h"
 
 #include "../smartMessageQueue.hpp"
 

--- a/SeRoNetSDK/SeRoNet/Utils/Task.hpp
+++ b/SeRoNetSDK/SeRoNet/Utils/Task.hpp
@@ -7,8 +7,8 @@
 #include <thread>
 #include <atomic>
 
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartIComponent.h"
-#include "../../../SmartSoftComponentDeveloperAPIcpp/SmartSoft_CD_API/smartITask.h"
+#include "smartIComponent.h"
+#include "smartITask.h"
 #include "../Exceptions/NotImplementedException.hpp"
 
 namespace SeRoNet {

--- a/SeRoNetSDKConfig.cmake.in
+++ b/SeRoNetSDKConfig.cmake.in
@@ -3,7 +3,8 @@
 include(CMakeFindDependencyMacro)
 find_dependency(open62541)
 find_dependency(Open62541Cpp)
-find_dependency(SmartSoft_CD_API)
+
+find_package(SmartSoft_CD_API PATHS $ENV{SMART_ROOT_ACE}/modules)
 
 include ("@PACKAGE_target_install_dest_name@")
 

--- a/tests/Test_Push.cpp
+++ b/tests/Test_Push.cpp
@@ -67,8 +67,12 @@ class CoordinateObject :
 
 };
 
+namespace SeRoNet {
+namespace CommunicationObjects {
+namespace Description {
+
 template<>
-SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::CommunicationObjects::Description::SelfDescription<
+IDescription::shp_t SelfDescription<
     CoordinateObject>(CoordinateObject *obj, std::string name) {
 
   SeRoNet::CommunicationObjects::Description::ComplexType::shp_t ret(
@@ -102,6 +106,10 @@ SeRoNet::CommunicationObjects::Description::IDescription::shp_t SeRoNet::Communi
       )
   );
   return ret;
+}
+
+}
+}
 }
 
 TEST(Push, ComplexDataTypeGetUpdate) {


### PR DESCRIPTION
This commit solves numerous GCC compiler errors related to namespace declaration of SelfDescription template specifications. Moreover, the usage of the SmarSoft CD API has been fixed (i.e. no hardcoded include paths anymore but configured through CMake).